### PR TITLE
Improve login and dashboard responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,36 +1,3 @@
-<style id="qr-video-controls-hide">
-</style>
-<style id="tribuna-select-style">
-  /* Solo para el select de TRIBUNA */
-  #seatTribuna { 
-    -webkit-appearance: none; -moz-appearance: none; appearance: none; 
-    background: linear-gradient(180deg, rgba(31,41,55,.85), rgba(17,24,39,.95));
-    color: #fff; 
-    border: 1px solid #374151; 
-    border-radius: 12px; 
-    padding: 0.65rem 2.25rem 0.65rem 0.9rem; 
-    font-weight: 600; 
-    line-height: 1.2; 
-    box-shadow: inset 0 1px 0 rgba(255,255,255,.06), 0 10px 18px rgba(0,0,0,.35);
-    transition: border-color .2s ease, box-shadow .2s ease, background .2s ease, transform .06s ease;
-  }
-  #seatTribuna:hover { border-color: #4B5563; }
-  #seatTribuna:focus { outline: none; border-color: #D32F2F; box-shadow: 0 0 0 3px rgba(211,47,47,.35), inset 0 1px 0 rgba(255,255,255,.06); }
-  #seatTribuna:active { transform: translateY(1px); }
-  #seatTribuna:disabled { opacity: .6; cursor: not-allowed; }
-  #seatTribuna::-ms-expand { display: none; } /* IE arrow */
-  #seatTribuna option { background: #0B1220; color: #fff; }
-  /* Oculta cualquier overlay/controles por defecto del <video> en iOS Safari */
-  #qrVideo::-webkit-media-controls-start-playback-button,
-  #qrVideo::-webkit-media-controls,
-  video::-webkit-media-controls {
-    display: none !important;
-    -webkit-appearance: none;
-    opacity: 0 !important; /* evita destellos */
-  }
-  /* Clase para ocultar el video hasta que la cámara esté lista */
-  #qrVideo.media-hidden { opacity: 0; }
-</style>
 <!DOCTYPE html>
 
 <html lang="es">
@@ -56,6 +23,40 @@
             }
         }
     </script>
+
+    <style id="qr-video-controls-hide">
+    </style>
+    <style id="tribuna-select-style">
+      /* Solo para el select de TRIBUNA */
+      #seatTribuna {
+        -webkit-appearance: none; -moz-appearance: none; appearance: none;
+        background: linear-gradient(180deg, rgba(31,41,55,.85), rgba(17,24,39,.95));
+        color: #fff;
+        border: 1px solid #374151;
+        border-radius: 12px;
+        padding: 0.65rem 2.25rem 0.65rem 0.9rem;
+        font-weight: 600;
+        line-height: 1.2;
+        box-shadow: inset 0 1px 0 rgba(255,255,255,.06), 0 10px 18px rgba(0,0,0,.35);
+        transition: border-color .2s ease, box-shadow .2s ease, background .2s ease, transform .06s ease;
+      }
+      #seatTribuna:hover { border-color: #4B5563; }
+      #seatTribuna:focus { outline: none; border-color: #D32F2F; box-shadow: 0 0 0 3px rgba(211,47,47,.35), inset 0 1px 0 rgba(255,255,255,.06); }
+      #seatTribuna:active { transform: translateY(1px); }
+      #seatTribuna:disabled { opacity: .6; cursor: not-allowed; }
+      #seatTribuna::-ms-expand { display: none; } /* IE arrow */
+      #seatTribuna option { background: #0B1220; color: #fff; }
+      /* Oculta cualquier overlay/controles por defecto del <video> en iOS Safari */
+      #qrVideo::-webkit-media-controls-start-playback-button,
+      #qrVideo::-webkit-media-controls,
+      video::-webkit-media-controls {
+        display: none !important;
+        -webkit-appearance: none;
+        opacity: 0 !important; /* evita destellos */
+      }
+      /* Clase para ocultar el video hasta que la cámara esté lista */
+      #qrVideo.media-hidden { opacity: 0; }
+    </style>
 
     <script id="profile-script">
     (function() {
@@ -353,22 +354,10 @@
     min-height: 100vh;
     scroll-behavior: smooth;
   }
-  /* Responsive container for main content */
-  main {
-    width: 100%;
-    max-width: 420px;
+  /* Responsive container for the authentication panel */
+  .auth-shell {
+    width: min(100%, clamp(22rem, 90vw, 44rem));
     margin: 0 auto;
-    padding: 1.5rem 1rem;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    min-height: 80vh;
-  }
-  @media (min-width: 640px){
-    main { max-width: 540px; padding: 2.5rem 2rem; }
-  }
-  @media (min-width: 1024px){
-    main { max-width: 700px; padding: 3rem 2.5rem; }
   }
   /* Glassmorphism cards/panels */
   .bg-america-dark\/90, .bg-america-dark\/95, .bg-gray-900.rounded-xl, .glass-card {
@@ -611,7 +600,8 @@
     }
   }
   /* Responsive header/footer */
-  header, footer {
+  body:not(.dashboard-mode) header,
+  body:not(.dashboard-mode) footer {
     width: 100%;
     max-width: 700px;
     margin: 0 auto;
@@ -619,16 +609,7 @@
     padding-right: 1rem;
   }
   /* Responsive for login section */
-  #loginSection > main {
-    max-width: 420px;
-    width: 100%;
-    margin: 0 auto;
-    padding: 1.5rem 0.5rem;
-  }
   @media (max-width: 480px){
-    #loginSection > main {
-      padding: 1rem 0.2rem;
-    }
     .bg-america-dark\/90, .bg-america-dark\/95, .bg-gray-900.rounded-xl {
       padding: 1.1rem !important;
     }
@@ -963,7 +944,6 @@ html,body{ background:#05070f !important; }
   </style>
 <style id="quick-pretty-pass">
   /* Quick visual polish focused on the login screen */
-  #loginSection main{ max-width: 440px; }
   #loginSection [class*="bg-america-dark"]{ border-radius: 18px !important; box-shadow: 0 20px 60px rgba(0,0,0,.35) !important; }
   #loginSection h1{ letter-spacing:.2px; line-height:1.18; }
   #loginSection p{ color:#d1d5db; }
@@ -1575,8 +1555,8 @@ html,body{ background:#05070f !important; }
           </div>
         </div>
       </aside>
-      <div class="order-1 w-full max-w-xl lg:order-2 lg:justify-self-end">
-        <div role="main" class="rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-2xl backdrop-blur-xl sm:p-8">
+      <div class="order-1 w-full lg:order-2 lg:justify-self-end">
+        <div role="main" class="auth-shell rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-2xl backdrop-blur-xl sm:p-8">
           <div class="space-y-8">
             <div class="space-y-4 text-center">
               <div class="relative mx-auto flex h-24 w-24 items-center justify-center rounded-full bg-gradient-to-br from-rose-500 via-red-500 to-red-600 shadow-2xl ring-4 ring-white/10">
@@ -5890,10 +5870,6 @@ html,body{ background:#05070f !important; }
       if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', start); else start();
     })();
   </script>
-</body>
-</html>
-
-
   <script id="flash-script">
   (function(){
     let flashStream = null;
@@ -6028,3 +6004,5 @@ html,body{ background:#05070f !important; }
     window.addEventListener('beforeunload', stopFlash);
   })();
   </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace the global `<main>` sizing rule with an `auth-shell` helper so the login card scales by viewport instead of constraining the dashboard
- scope the header/footer width constraint to non-dashboard views and attach the new helper class to the login container

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db844c35e08331afc368c998ce558a