### PR TITLE
Improve button text wrapping and mobile login scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,36 +1,3 @@
-<style id="qr-video-controls-hide">
-</style>
-<style id="tribuna-select-style">
-  /* Solo para el select de TRIBUNA */
-  #seatTribuna { 
-    -webkit-appearance: none; -moz-appearance: none; appearance: none; 
-    background: linear-gradient(180deg, rgba(31,41,55,.85), rgba(17,24,39,.95));
-    color: #fff; 
-    border: 1px solid #374151; 
-    border-radius: 12px; 
-    padding: 0.65rem 2.25rem 0.65rem 0.9rem; 
-    font-weight: 600; 
-    line-height: 1.2; 
-    box-shadow: inset 0 1px 0 rgba(255,255,255,.06), 0 10px 18px rgba(0,0,0,.35);
-    transition: border-color .2s ease, box-shadow .2s ease, background .2s ease, transform .06s ease;
-  }
-  #seatTribuna:hover { border-color: #4B5563; }
-  #seatTribuna:focus { outline: none; border-color: #D32F2F; box-shadow: 0 0 0 3px rgba(211,47,47,.35), inset 0 1px 0 rgba(255,255,255,.06); }
-  #seatTribuna:active { transform: translateY(1px); }
-  #seatTribuna:disabled { opacity: .6; cursor: not-allowed; }
-  #seatTribuna::-ms-expand { display: none; } /* IE arrow */
-  #seatTribuna option { background: #0B1220; color: #fff; }
-  /* Oculta cualquier overlay/controles por defecto del <video> en iOS Safari */
-  #qrVideo::-webkit-media-controls-start-playback-button,
-  #qrVideo::-webkit-media-controls,
-  video::-webkit-media-controls {
-    display: none !important;
-    -webkit-appearance: none;
-    opacity: 0 !important; /* evita destellos */
-  }
-  /* Clase para ocultar el video hasta que la cámara esté lista */
-  #qrVideo.media-hidden { opacity: 0; }
-</style>
 <!DOCTYPE html>
 
 <html lang="es">
@@ -56,6 +23,180 @@
             }
         }
     </script>
+
+    <style id="qr-video-controls-hide">
+    </style>
+    <style id="tribuna-select-style">
+      /* Solo para el select de TRIBUNA */
+      #seatTribuna {
+        -webkit-appearance: none; -moz-appearance: none; appearance: none;
+        background: linear-gradient(180deg, rgba(31,41,55,.85), rgba(17,24,39,.95));
+        color: #fff;
+        border: 1px solid #374151;
+        border-radius: 12px;
+        padding: 0.65rem 2.25rem 0.65rem 0.9rem;
+        font-weight: 600;
+        line-height: 1.2;
+        box-shadow: inset 0 1px 0 rgba(255,255,255,.06), 0 10px 18px rgba(0,0,0,.35);
+        transition: border-color .2s ease, box-shadow .2s ease, background .2s ease, transform .06s ease;
+      }
+      #seatTribuna:hover { border-color: #4B5563; }
+      #seatTribuna:focus { outline: none; border-color: #D32F2F; box-shadow: 0 0 0 3px rgba(211,47,47,.35), inset 0 1px 0 rgba(255,255,255,.06); }
+      #seatTribuna:active { transform: translateY(1px); }
+      #seatTribuna:disabled { opacity: .6; cursor: not-allowed; }
+      #seatTribuna::-ms-expand { display: none; } /* IE arrow */
+      #seatTribuna option { background: #0B1220; color: #fff; }
+      /* Oculta cualquier overlay/controles por defecto del <video> en iOS Safari */
+      #qrVideo::-webkit-media-controls-start-playback-button,
+      #qrVideo::-webkit-media-controls,
+      video::-webkit-media-controls {
+        display: none !important;
+        -webkit-appearance: none;
+        opacity: 0 !important; /* evita destellos */
+      }
+      /* Clase para ocultar el video hasta que la cámara esté lista */
+      #qrVideo.media-hidden { opacity: 0; }
+    </style>
+
+    <style id="button-compact-style">
+      button {
+        white-space: normal !important;
+        overflow-wrap: anywhere;
+        line-height: 1.35;
+      }
+      button[class~="text-2xl"],
+      button[class~="text-xl"],
+      button[class~="text-lg"] {
+        font-size: 1.05rem !important;
+      }
+
+      button[class~="text-base"] {
+        font-size: 0.95rem !important;
+      }
+
+      button[class~="text-sm"] {
+        font-size: 0.8rem !important;
+      }
+
+      button[class~="text-xs"],
+      button[class~="text-[0.75rem]"] {
+        font-size: 0.7rem !important;
+      }
+
+      button[class~="py-5"] {
+        padding-top: 0.95rem !important;
+        padding-bottom: 0.95rem !important;
+      }
+
+      button[class~="py-4"] {
+        padding-top: 0.85rem !important;
+        padding-bottom: 0.85rem !important;
+      }
+
+      button[class~="py-3"] {
+        padding-top: 0.65rem !important;
+        padding-bottom: 0.65rem !important;
+      }
+
+      button[class~="py-2.5"] {
+        padding-top: 0.55rem !important;
+        padding-bottom: 0.55rem !important;
+      }
+
+      button[class~="py-2"] {
+        padding-top: 0.45rem !important;
+        padding-bottom: 0.45rem !important;
+      }
+
+      button[class~="py-1.5"] {
+        padding-top: 0.32rem !important;
+        padding-bottom: 0.32rem !important;
+      }
+
+      button[class~="py-1"] {
+        padding-top: 0.24rem !important;
+        padding-bottom: 0.24rem !important;
+      }
+
+      button[class~="py-0.5"] {
+        padding-top: 0.18rem !important;
+        padding-bottom: 0.18rem !important;
+      }
+
+      button[class~="px-6"] {
+        padding-left: 1.25rem !important;
+        padding-right: 1.25rem !important;
+      }
+
+      button[class~="px-5"] {
+        padding-left: 1.05rem !important;
+        padding-right: 1.05rem !important;
+      }
+
+      button[class~="px-4"] {
+        padding-left: 0.9rem !important;
+        padding-right: 0.9rem !important;
+      }
+
+      button[class~="px-3"] {
+        padding-left: 0.7rem !important;
+        padding-right: 0.7rem !important;
+      }
+
+      button[class~="px-2.5"] {
+        padding-left: 0.58rem !important;
+        padding-right: 0.58rem !important;
+      }
+
+      button[class~="px-2"] {
+        padding-left: 0.48rem !important;
+        padding-right: 0.48rem !important;
+      }
+
+      button[class~="p-3"] {
+        padding: 0.65rem !important;
+      }
+
+      button[class~="p-2.5"] {
+        padding: 0.55rem !important;
+      }
+
+      button[class~="p-2"] {
+        padding: 0.45rem !important;
+      }
+
+      button[class~="p-1.5"] {
+        padding: 0.32rem !important;
+      }
+
+      button[class~="p-1"] {
+        padding: 0.24rem !important;
+      }
+
+      button[class~="rounded-3xl"] {
+        border-radius: 1.35rem !important;
+      }
+
+      button[class~="rounded-2xl"] {
+        border-radius: 1rem !important;
+      }
+
+      button[class~="rounded-xl"] {
+        border-radius: 0.8rem !important;
+      }
+
+      button[class~="rounded-lg"] {
+        border-radius: 0.65rem !important;
+      }
+
+      button[class~="rounded-md"] {
+        border-radius: 0.45rem !important;
+      }
+
+      button[class~="rounded"] {
+        border-radius: 0.4rem !important;
+      }
+    </style>
 
     <script id="profile-script">
     (function() {
@@ -353,22 +494,10 @@
     min-height: 100vh;
     scroll-behavior: smooth;
   }
-  /* Responsive container for main content */
-  main {
-    width: 100%;
-    max-width: 420px;
+  /* Responsive container for the authentication panel */
+  .auth-shell {
+    width: min(100%, clamp(22rem, 90vw, 44rem));
     margin: 0 auto;
-    padding: 1.5rem 1rem;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    min-height: 80vh;
-  }
-  @media (min-width: 640px){
-    main { max-width: 540px; padding: 2.5rem 2rem; }
-  }
-  @media (min-width: 1024px){
-    main { max-width: 700px; padding: 3rem 2.5rem; }
   }
   /* Glassmorphism cards/panels */
   .bg-america-dark\/90, .bg-america-dark\/95, .bg-gray-900.rounded-xl, .glass-card {
@@ -611,7 +740,8 @@
     }
   }
   /* Responsive header/footer */
-  header, footer {
+  body:not(.dashboard-mode) header,
+  body:not(.dashboard-mode) footer {
     width: 100%;
     max-width: 700px;
     margin: 0 auto;
@@ -619,16 +749,7 @@
     padding-right: 1rem;
   }
   /* Responsive for login section */
-  #loginSection > main {
-    max-width: 420px;
-    width: 100%;
-    margin: 0 auto;
-    padding: 1.5rem 0.5rem;
-  }
   @media (max-width: 480px){
-    #loginSection > main {
-      padding: 1rem 0.2rem;
-    }
     .bg-america-dark\/90, .bg-america-dark\/95, .bg-gray-900.rounded-xl {
       padding: 1.1rem !important;
     }
@@ -963,7 +1084,10 @@ html,body{ background:#05070f !important; }
   </style>
 <style id="quick-pretty-pass">
   /* Quick visual polish focused on the login screen */
-  #loginSection main{ max-width: 440px; }
+  #loginSection{
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-y: contain;
+  }
   #loginSection [class*="bg-america-dark"]{ border-radius: 18px !important; box-shadow: 0 20px 60px rgba(0,0,0,.35) !important; }
   #loginSection h1{ letter-spacing:.2px; line-height:1.18; }
   #loginSection p{ color:#d1d5db; }
@@ -1489,7 +1613,7 @@ html,body{ background:#05070f !important; }
     #iosNfcModal, #iosNfcBackdrop{ min-height:100dvh; }
   }
 </style>
-<div id="loginSection" class="relative isolate min-h-screen overflow-hidden">
+<div id="loginSection" class="relative isolate min-h-screen overflow-x-hidden overflow-y-auto lg:overflow-hidden">
   <div class="absolute inset-0 -z-10">
     <div class="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(248,113,113,0.22),_transparent_55%)]"></div>
     <div class="absolute inset-0 bg-[linear-gradient(130deg,_rgba(2,6,23,0.92),_rgba(88,28,135,0.35),_rgba(15,23,42,0.9))]"></div>
@@ -1497,7 +1621,7 @@ html,body{ background:#05070f !important; }
     <div class="absolute inset-y-0 right-0 hidden w-2/3 bg-gradient-to-l from-black/70 to-transparent lg:block"></div>
   </div>
   <div class="relative mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 py-12 sm:px-10 lg:px-16">
-    <div class="grid flex-1 items-center gap-12 py-6 lg:grid-cols-[1.08fr_minmax(0,1fr)] lg:py-12">
+    <div class="grid flex-1 items-start gap-12 py-6 lg:grid-cols-[1.08fr_minmax(0,1fr)] lg:items-center lg:py-12">
       <aside class="order-2 space-y-10 text-slate-100 lg:order-1">
         <div class="rounded-3xl border border-white/10 bg-white/10 p-8 shadow-2xl backdrop-blur-2xl">
           <span class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-white/70">
@@ -1575,8 +1699,8 @@ html,body{ background:#05070f !important; }
           </div>
         </div>
       </aside>
-      <div class="order-1 w-full max-w-xl lg:order-2 lg:justify-self-end">
-        <div role="main" class="rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-2xl backdrop-blur-xl sm:p-8">
+      <div class="order-1 w-full lg:order-2 lg:justify-self-end">
+        <div role="main" class="auth-shell rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-2xl backdrop-blur-xl sm:p-8">
           <div class="space-y-8">
             <div class="space-y-4 text-center">
               <div class="relative mx-auto flex h-24 w-24 items-center justify-center rounded-full bg-gradient-to-br from-rose-500 via-red-500 to-red-600 shadow-2xl ring-4 ring-white/10">
@@ -5890,10 +6014,6 @@ html,body{ background:#05070f !important; }
       if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', start); else start();
     })();
   </script>
-</body>
-</html>
-
-
   <script id="flash-script">
   (function(){
     let flashStream = null;
@@ -6028,3 +6148,5 @@ html,body{ background:#05070f !important; }
     window.addEventListener('beforeunload', stopFlash);
   })();
   </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow button labels to wrap by default and prevent text overflow inside compact buttons
- enable vertical scrolling for the login shell on small screens while keeping desktop layout centered
- add iOS-specific scrolling hints to smooth the mobile experience

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db844c35e08331afc368c998ce558a